### PR TITLE
Added “How to contribute” to the `site-menu`

### DIFF
--- a/src/documents/pages/how-to-contribute.html.md
+++ b/src/documents/pages/how-to-contribute.html.md
@@ -1,5 +1,6 @@
 ---
 title: How to contribute
+order: 3
 ---
 
 # How to contribute


### PR DESCRIPTION
I propose to move “how to contribute” to the site's menu. This would a) make this page more accessible, so you won't need to crawl through the “About” text in order to find it, and b) it would make a better impression of the project's homepage, as it would instantly make it tell you that you can contribute.
